### PR TITLE
Multi vendor support

### DIFF
--- a/smbios_validation_tool/constants.py
+++ b/smbios_validation_tool/constants.py
@@ -72,3 +72,4 @@ class FieldValueRegexps(enum.Enum):
   SOCKET_DESIGNATION_REGEXP = r'(CPU|P)\d+'
   DEVICE_LOCATOR_REGEXP = r'(?:[^\d]*)\d+'
   BANK_LOCATOR_REGEXP = r'.*(Node|Channel).*'
+  VENDORS_REGEXP = r'.*(Intel|Google|Dell|Lenova).*'

--- a/smbios_validation_tool/constants.py
+++ b/smbios_validation_tool/constants.py
@@ -72,4 +72,4 @@ class FieldValueRegexps(enum.Enum):
   SOCKET_DESIGNATION_REGEXP = r'(CPU|P)\d+'
   DEVICE_LOCATOR_REGEXP = r'(?:[^\d]*)\d+'
   BANK_LOCATOR_REGEXP = r'.*(Node|Channel).*'
-  VENDORS_REGEXP = r'.*(Intel|Google|Dell|Lenova).*'
+  VENDORS_REGEXP = r'(?i).*(Intel|Google|Dell|Lenova|Marvel|Nivida|AMD|Mellanox).*'

--- a/smbios_validation_tool/rules.py
+++ b/smbios_validation_tool/rules.py
@@ -57,7 +57,8 @@ rules = [
             [matcher.RecordTypeMatcher(constants.RecordType.BIOS_RECORD)]),
         validator.IndividualValidator([
             validator.FieldPresentChecker('Vendor'),
-            validator.FieldValueRegexpChecker('Vendor', r'.*Google.*')
+            validator.FieldValueRegexpChecker('Vendor',
+                constants.FieldValueRegexps.VENDORS_REGEXP.value)
         ]), 'ERROR: Invalid Vendor field in Type 0 (BIOS Information) record.',
         ('ACTION: BIOS Vendor string should contain "Google".\n'
          'Without that our software will ignore the OEM structures.')),

--- a/smbios_validation_tool/validator.py
+++ b/smbios_validation_tool/validator.py
@@ -171,6 +171,8 @@ class HandleFieldChecker:
     handle_id = record.props[self.field].val
     # Make sure the format of handle id is equivalent to all other handles
     # e.g. '0x123' will become '0x0123'.
+    if handle_id == 'Not Provided':
+        return False
     handle_id = '0x{:04X}'.format(int(handle_id, 16))
     if handle_id not in records:
       return False


### PR DESCRIPTION
This PR adds Intel, Dell, Lenova, Marvel, Nivida, AMD and Mellanox to the allowed vendors in the BIOS info vendor field. It also resolves a bug where "Not Provided" is returned from the dmi table. 